### PR TITLE
Add suport for Resource Tagging, NIST and newer versions of CIS.

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,11 @@ The following resources will be created:
 | members | List of member AWS accounts as [{account\_id: '9999', email: 'a@b.com'}, {...}] } | `list(any)` | `[]` | no |
 | severity\_list | n/a | `list(any)` | <pre>[<br>  "HIGH",<br>  "CRITICAL"<br>]</pre> | no |
 | subscription\_cis | Enables CIS Foundations Benchmark Standards subscription | `bool` | `false` | no |
+| subscription\_cis\_version | The version of the CIS AWS Foundations Benchmark to subscribe to | `string` | `"3.0.0"` | no |
 | subscription\_foundational | Enables AWS Foundational Security Best Practices subscription | `bool` | `false` | no |
+| subscription\_nist | Enables AWS NIST SP 800-53 subscription | `bool` | `false` | no |
 | subscription\_pci | Enables PCI-DSS Standards subscription | `bool` | `false` | no |
+| subscription\_resource\_tagging | Enables AWS Resource Tagging Standard subscription | `bool` | `false` | no |
 
 ## Outputs
 

--- a/_variables.tf
+++ b/_variables.tf
@@ -10,10 +10,29 @@ variable "subscription_cis" {
   description = "Enables CIS Foundations Benchmark Standards subscription"
 }
 
+variable "subscription_cis_version" {
+  type        = string
+  nullable    = false
+  default     = "3.0.0"
+  description = "The version of the CIS AWS Foundations Benchmark to subscribe to"
+}
+
 variable "subscription_foundational" {
   type        = bool
   default     = false
   description = "Enables AWS Foundational Security Best Practices subscription"
+}
+
+variable "subscription_resource_tagging" {
+  type        = bool
+  default     = false
+  description = "Enables AWS Resource Tagging Standard subscription"
+}
+
+variable "subscription_nist" {
+  type        = bool
+  default     = false
+  description = "Enables AWS NIST SP 800-53 subscription"
 }
 
 variable "severity_list" {

--- a/securityhub.tf
+++ b/securityhub.tf
@@ -8,15 +8,31 @@ resource "aws_securityhub_standards_subscription" "pci" {
 }
 
 resource "aws_securityhub_standards_subscription" "cis" {
-  count         = var.subscription_cis ? 1 : 0
-  depends_on    = [aws_securityhub_account.default]
-  standards_arn = "arn:aws:securityhub:::ruleset/cis-aws-foundations-benchmark/v/1.2.0"
+  count      = var.subscription_cis ? 1 : 0
+  depends_on = [aws_securityhub_account.default]
+  standards_arn = (
+    var.subscription_cis_version == "1.2.0"
+    ? "arn:aws:securityhub:::ruleset/cis-aws-foundations-benchmark/v/1.2.0"
+    : "arn:aws:securityhub:${data.aws_region.current.name}::standards/cis-aws-foundations-benchmark/v/${var.subscription_cis_version}"
+  )
 }
 
 resource "aws_securityhub_standards_subscription" "foundational" {
   count         = var.subscription_foundational ? 1 : 0
   depends_on    = [aws_securityhub_account.default]
   standards_arn = "arn:aws:securityhub:${data.aws_region.current.name}::standards/aws-foundational-security-best-practices/v/1.0.0"
+}
+
+resource "aws_securityhub_standards_subscription" "resource_tagging" {
+  count         = var.subscription_resource_tagging ? 1 : 0
+  depends_on    = [aws_securityhub_account.default]
+  standards_arn = "arn:aws:securityhub:${data.aws_region.current.name}::standards/aws-resource-tagging-standard/v/1.0.0"
+}
+
+resource "aws_securityhub_standards_subscription" "nist" {
+  count         = var.subscription_nist ? 1 : 0
+  depends_on    = [aws_securityhub_account.default]
+  standards_arn = "arn:aws:securityhub:${data.aws_region.current.name}::standards/nist-800-53/v/5.0.0"
 }
 
 resource "aws_securityhub_member" "members" {


### PR DESCRIPTION
There are a few new standards in AWS Security Hub that aren't covered by this module, including:
* [National Institute of Standards and Technology (NIST) SP 800-53 Rev. 5](https://docs.aws.amazon.com/securityhub/latest/userguide/nist-standard.html)
* [AWS Resource Tagging Standard](https://docs.aws.amazon.com/securityhub/latest/userguide/standards-tagging.html)
* [CIS AWS Foundations Benchmark v1.4.0 and v3.0.0](https://docs.aws.amazon.com/securityhub/latest/userguide/cis-aws-foundations-benchmark.html)

This PR aims to address those limitations.

## Types of changes

What types of changes does your code introduce to <repo_name>?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the CONTRIBUTING.md doc.
- [x] I have added necessary documentation (if appropriate).
- [x] Any dependent changes have been merged and published in downstream modules.

## Further comments

These modifications _could be_ considered to be breaking changes, as the default version of CIS AWS Foundations Benchmark has been set to v3.0.0, whereas previously it was hard-coded to v1.2.0. If this is undesirable behaviour, the default value can be dropped back to "1.2.0".